### PR TITLE
fix the packaging issue by allowing files that begin with dot

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frankenstack",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frankenstack",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "bin/index.js",
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -93,7 +93,7 @@ export default class Deployer {
         });
         
         archive.pipe(output);
-        archive.glob('**', {ignore: 'node_modules/**'});
+        archive.glob('**', {ignore: 'node_modules/**', dot: true});
         archive.finalize();
 
         const upload = new Upload({


### PR DESCRIPTION
The issue was because the new method of archiving was ignoring files that began with a dot. It appears the release of jsii overnight made this bug appear.