### PR TITLE
Rollback issue fix

### DIFF
--- a/packages/api/generated/Observers/ComponentRollbackQueryResponseHandler.spec.ts
+++ b/packages/api/generated/Observers/ComponentRollbackQueryResponseHandler.spec.ts
@@ -1,0 +1,183 @@
+import { Component } from "../Entities/Component";
+import { ComponentDeployment } from "../Entities/ComponentDeployment";
+import { ComponentRollbackQuery } from "../Entities/ComponentRollbackQuery"
+import { createNewObservation, generateTraceId } from "../Observation2";
+import { ComponentRollbackQueryResponseHandler } from './ComponentRollbackQueryResponseHandler';
+
+describe('ComponentRollbackQuery_resp', () => {
+    it('returns last component deployment', () => {
+        const rollbackQuery: ComponentRollbackQuery.DataSchema = {
+            ComponentName: 'comp',
+            Env: 'test'
+        };
+
+        const rollbackQueryObservation = createNewObservation(
+            ComponentRollbackQuery.EntityObservation, 
+            rollbackQuery,
+            generateTraceId()
+        );
+
+        const component: Component.DataSchema = {
+            DeploymentGuid: 'foo',
+            Env: 'test',
+            Name: 'comp',
+            Status: "DEPLOYED",
+            Create: new Date().toISOString(),
+            Update: new Date().toISOString()
+        };
+
+        const componentObservation = createNewObservation(
+            Component.EntityObservation,
+            component,
+            generateTraceId()
+        );
+
+        const component2: Component.DataSchema = {
+            DeploymentGuid: 'bar',
+            Env: 'test',
+            Name: 'comp',
+            Status: "DEPLOYED",
+            Create: new Date().toISOString(),
+            Update: new Date().toISOString()
+        };
+
+        const componentObservation2 = createNewObservation(
+            Component.EntityObservation,
+            component2,
+            generateTraceId()
+        );
+
+        const componentDeployment: ComponentDeployment.DataSchema = {
+            DeploymentGuid: 'foo',
+            Env: 'test',
+            Name: "comp",
+            Provider: {
+                Name: 'provider',
+                Config: [{
+                    Key: 'key',
+                    Value: 'value'
+                }]
+            },
+        };
+
+        const componentDeploymentObservation = createNewObservation(
+            ComponentDeployment.EntityObservation,
+            componentDeployment,
+            generateTraceId()
+        );
+
+        const componentDeployment2: ComponentDeployment.DataSchema = {
+            DeploymentGuid: 'bar',
+            Env: 'test',
+            Name: "comp",
+            Provider: {
+                Name: 'provider',
+                Config: [{
+                    Key: 'key',
+                    Value: 'value'
+                }]
+            },
+        };
+
+        const componentDeploymentObservation2 = createNewObservation(
+            ComponentDeployment.EntityObservation,
+            componentDeployment2,
+            generateTraceId()
+        );
+
+        const dependentObservations = [[componentObservation, componentObservation2], [componentDeploymentObservation, componentDeploymentObservation2]];
+
+        const resp: any = ComponentRollbackQueryResponseHandler(rollbackQueryObservation, dependentObservations, { time: new Date() })
+        
+        expect(resp.deploymentGuid).toEqual('bar');
+    });
+
+    it('ignores null provider configs', () => {
+        const rollbackQuery: ComponentRollbackQuery.DataSchema = {
+            ComponentName: 'comp',
+            Env: 'test'
+        };
+
+        const rollbackQueryObservation = createNewObservation(
+            ComponentRollbackQuery.EntityObservation, 
+            rollbackQuery,
+            generateTraceId()
+        );
+
+        const component: Component.DataSchema = {
+            DeploymentGuid: 'foo',
+            Env: 'test',
+            Name: 'comp',
+            Status: "DEPLOYED",
+            Create: new Date().toISOString(),
+            Update: new Date().toISOString()
+        };
+
+        const componentObservation = createNewObservation(
+            Component.EntityObservation,
+            component,
+            generateTraceId()
+        );
+
+        const component2: Component.DataSchema = {
+            DeploymentGuid: 'bar',
+            Env: 'test',
+            Name: 'comp',
+            Status: "DEPLOYED",
+            Create: new Date().toISOString(),
+            Update: new Date().toISOString()
+        };
+
+        const componentObservation2 = createNewObservation(
+            Component.EntityObservation,
+            component2,
+            generateTraceId()
+        );
+
+        const componentDeployment: ComponentDeployment.DataSchema = {
+            DeploymentGuid: 'foo',
+            Env: 'test',
+            Name: "comp",
+            Provider: {
+                Name: 'provider',
+                Config: [{
+                    Key: 'key',
+                    Value: 'value'
+                }]
+            },
+        };
+
+        const componentDeploymentObservation = createNewObservation(
+            ComponentDeployment.EntityObservation,
+            componentDeployment,
+            generateTraceId()
+        );
+
+        const componentDeployment2: ComponentDeployment.DataSchema = {
+            DeploymentGuid: 'bar',
+            Env: 'test',
+            Name: "comp",
+            Provider: {
+                Name: 'provider',
+                Config: [{
+                    Key: 'key',
+                    // @ts-ignore
+                    Value: null
+                }]
+            },
+        };
+
+        const componentDeploymentObservation2 = createNewObservation(
+            ComponentDeployment.EntityObservation,
+            componentDeployment2,
+            generateTraceId()
+        );
+
+        const dependentObservations = [[componentObservation, componentObservation2], [componentDeploymentObservation, componentDeploymentObservation2]];
+
+        const resp: any = ComponentRollbackQueryResponseHandler(rollbackQueryObservation, dependentObservations, { time: new Date() })
+        
+        expect(resp.deploymentGuid).toEqual('bar');
+        expect(resp.provider.config).toEqual([]);
+    });
+})

--- a/packages/api/generated/Observers/ComponentRollbackQueryResponseHandler.ts
+++ b/packages/api/generated/Observers/ComponentRollbackQueryResponseHandler.ts
@@ -37,7 +37,9 @@ export function ComponentRollbackQueryResponseHandler(
     provider: {
       name: componentDeployment.data.Provider.Name,
       config: componentDeployment.data.Provider.Config
-        ? componentDeployment.data.Provider.Config.map(configItem => {
+        ? componentDeployment.data.Provider.Config.filter(configItem => {
+          return configItem.Key && configItem.Value 
+        }).map(configItem => {
             return {
               name: configItem.Key,
               value: configItem.Value

--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -93,8 +93,8 @@ input ProviderInput {
 
 
 input KeyValueInput {
-    name: String
-    value: String
+    name: String!
+    value: String!
 }
 
 input Statement {


### PR DESCRIPTION
This fixes the rollback issue were were seeing with this error: `ERROR: GraphQL error: Cannot return null for non-nullable type: 'String' within parent 'KeyValue' (/getComponentRollbackState/provider/config[0]/value)`
We had templates that had a key with no value that was being allowed for the input but not when it was queried which caused graphql to error. This will enforce the value to be not null going forward and there is also logic now to filter out these null values so that we can rollback existing components.