### PR TITLE
Hotfix - Component describe secrets inputs masking

### DIFF
--- a/packages/api/generated/Observers/DescribeComponentQueryResponseHandler.spec.ts
+++ b/packages/api/generated/Observers/DescribeComponentQueryResponseHandler.spec.ts
@@ -65,4 +65,70 @@ describe('DescribeComponentQuery_resp', () => {
         expect(resp.outputs).toEqual([{name: 'foo', value: 'bar'}])
 
     });
+
+    it('secrets are masked in inputs', () => {
+        const describeComponentQuery: DescribeComponentQuery.DataSchema = {
+            Env: 'test',
+            ComponentName: 'comp'
+        }
+
+        const describeComponentQueryObservation = createNewObservation(
+            DescribeComponentQuery.EntityObservation,
+            describeComponentQuery,
+            generateTraceId()
+        );
+
+        const component: Component.DataSchema = {
+            DeploymentGuid: 'foo',
+            Env: 'test',
+            Name: 'comp',
+            Status: "DEPLOYED",
+            Create: new Date().toISOString(),
+            Update: new Date().toISOString(),
+            Outputs: [{
+                Key: 'foo',
+                Value: 'ssm:/test/comp/foo'
+            }]
+        };
+
+        const componentObservation = createNewObservation(
+            Component.EntityObservation,
+            component,
+            generateTraceId()
+        );
+
+        const componentDeployment: ComponentDeployment.DataSchema = {
+            DeploymentGuid: 'foo',
+            Env: 'test',
+            Name: "comp",
+            Provider: {
+                Name: 'secrets',
+                Config: [{
+                    Key: 'key',
+                    Value: 'value'
+                }]
+            },
+            Inputs: [{
+                Key: 'foo',
+                Value: 'mysuperlongverylongneverendingsecretkeythatnooneshouldknow'
+            }]
+        };
+
+        const componentDeploymentObservation = createNewObservation(
+            ComponentDeployment.EntityObservation,
+            componentDeployment,
+            generateTraceId()
+        );
+
+        const dependentObservations = [[componentObservation], [componentDeploymentObservation]]
+
+        const resp: any = DescribeComponentQueryResponseHandler(describeComponentQueryObservation, dependentObservations, { time: new Date()})
+
+        expect(resp.deploymentGuid).toEqual('foo')
+        expect(resp.name).toEqual('comp')
+        expect(resp.env).toEqual('test')
+        expect(resp.inputs[0].value).not.toEqual('mysuperlongverylongneverendingsecretkeythatnooneshouldknow')
+        expect(resp.inputs[0].value).toMatch(/m\*{1,18}w/)
+        expect(resp.outputs).toEqual([{name: 'foo', value: 'ssm:/test/comp/foo'}])
+    });
 })


### PR DESCRIPTION
Fixes an issue where if a component input is a secret, the secret value is exposed with the component describe feature. The issue is fixed by masking the secret value in this case.