### PR TITLE
Parameterized Deployments and Child Templates

### DIFF
--- a/packages/cli/bin/index.ts
+++ b/packages/cli/bin/index.ts
@@ -1,17 +1,38 @@
 #!/usr/bin/env node
 const minimist = require('minimist');
+const version = require('../package.json').version;
 import Deployer from '../src';
 
 const run = async () => {
     const args = minimist(process.argv);
     process.argv = process.argv.slice(0, 2);
-    const file = args._[3];
     const command = args._[2];
+    if(command === 'help') {
+        console.log(`
+Frankenstack v${version}
+
+Usage:
+    frank deploy <file> [--params=<'{"key": "value"}'>]
+    frank rollback <env> <componentName>
+    frank iam <file>
+    frank remove <env> <componentName>
+    frank component describe <env> <component>
+
+Options:
+    --profile   AWS profile to use
+    --stageOveride Use non-default Frankenstack API
+        `);
+        process.exit(0);
+    } else if(command === 'version') {
+        console.log(`Frankenstack CLI v${version}`);
+        process.exit(0);
+    }
+    const file = args._[3];
     const deploy = new Deployer(command, file, args);
     try {
         await deploy.run();
     } catch(err: any) {
-        console.error("ERROR:", err.message);
+        console.error("ERROR:", err.message ? err.message : err);
         process.exit(1);
     }
 }

--- a/packages/cli/bin/index.ts
+++ b/packages/cli/bin/index.ts
@@ -7,7 +7,7 @@ const run = async () => {
     const args = minimist(process.argv);
     process.argv = process.argv.slice(0, 2);
     const command = args._[2];
-    if(command === 'help') {
+    if(command === 'help' || args.help) {
         console.log(`
 Frankenstack v${version}
 
@@ -23,7 +23,7 @@ Options:
     --stageOveride Use non-default Frankenstack API
         `);
         process.exit(0);
-    } else if(command === 'version') {
+    } else if(command === 'version' || args.version) {
         console.log(`Frankenstack CLI v${version}`);
         process.exit(0);
     }

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frankenstack",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frankenstack",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "",
   "main": "bin/index.js",
   "bin": {

--- a/packages/cli/src/utils/variables.ts
+++ b/packages/cli/src/utils/variables.ts
@@ -1,0 +1,69 @@
+const flatten = require('flat');
+
+export function resolveComponents(template: any, params: any): any {
+    template.components = template.components.map((component: any) => {
+        if(component.provider.config) {
+            component.provider.config = Object.entries(component.provider.config).map(([key, value]) => {
+                return {
+                    name: key,
+                    value: value
+                }
+            })
+        }
+        if(component.inputs) {
+            component.inputs = flatten(component.inputs);
+            component.inputs = Object.entries(component.inputs).map(([key, value]) => {
+                return {
+                    name: key,
+                    value: typeof value === 'string' ? resolveInputVariables(value, template, params) : value
+                }
+            })
+        }
+        return component;
+    });
+    return template;
+}
+
+export function resolveInputVariables(rawValue: string, template: any, params: any): string {
+    const variablePattern = new RegExp(/(\$\{([^${}]*?)\})+/);
+    let match = variablePattern.exec(rawValue);
+    while(match) {
+        const matchValue = match[2];
+        const currentIndex = match.index + rawValue.indexOf(match.input);
+        const replaceValue = resolveReference(matchValue, template, params);
+        if(matchValue === replaceValue) {
+            match = variablePattern.exec(rawValue.substring(currentIndex + matchValue[1].length));
+        } else {
+            rawValue = rawValue.replace(match[1], replaceValue);
+            match = variablePattern.exec(rawValue);
+        }
+    }
+    return rawValue;
+}
+
+function resolveReference(reference: string, template: any, params: any): string {
+    let type = reference.split(':')[0];
+    let resolvedRef = reference;
+    switch(type) {
+        case 'self':
+            const property = reference.replace('self:', '');
+            if(template[property]) {
+                resolvedRef = template[property];
+            } else {
+                throw `Could not resolve reference: ${reference}`;
+            }
+            break;
+        case 'param':
+        case 'params':
+            const param = reference.replace(`${type}:`, '');
+            if(params[param]) {
+                resolvedRef = params[param];
+            } else {
+                throw `Could not resolve reference: ${reference}`
+            }
+            break;
+        default:
+            break;
+    }
+    return resolvedRef;
+}


### PR DESCRIPTION
- Supports sending parameters to a template via the CLI like: `frank deploy template.yml --params '{"key": "value"}'`
- Allows references in the templates to parameters for the environment and and component inputs using `${param:key}`
- Allows references to any value in the template using `self`. Example: `${self:env}`
- Supports child templates. See the [wiki ](https://github.com/DaySmart/frankenstack/wiki#parametrized-deployments-and-child-templates)for details.
- References can be nested and there can be multiple references in the same value.
- Implemented help and version commands